### PR TITLE
feat(payment-worker): implement cache invalidation producer

### DIFF
--- a/payment-worker/src/main/java/com/example/payment_worker/entity/Payment.java
+++ b/payment-worker/src/main/java/com/example/payment_worker/entity/Payment.java
@@ -68,5 +68,22 @@ public class Payment {
         this.id = id;
     }
 
+    // Explicit setters for PaymentWorker
+    public void setOrderId(String orderId) {
+        this.orderId = orderId;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public void setPaymentMethod(String paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
     // Các trường khác (ví dụ: thông tin người dùng, thời gian tạo)
 }

--- a/payment-worker/src/main/resources/application.yml
+++ b/payment-worker/src/main/resources/application.yml
@@ -23,6 +23,10 @@ spring:
       properties:
         spring.json.trusted.packages: com.example.payment_worker.dto
     topic: payment-topic
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 ---
 spring:
@@ -42,3 +46,7 @@ spring:
       properties:
         spring.json.trusted.packages: com.example.payment_worker.dto
     topic: payment-topic
+    producer:
+      bootstrap-servers: kafka:9093
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
This pull request implements the cache invalidation producer in the payment-worker service.

## Changes Included:

- **feat(payment-worker)**: Add KafkaTemplate to PaymentWorker for sending cache invalidation messages.
- **feat(payment-worker)**: Add explicit setters to Payment entity in payment-worker.
- **chore(payment-worker)**: Update application.yml with Kafka producer configuration.

## Key Features:

- **Cache Invalidation Producer**: Payment Worker now sends messages to Kafka to invalidate cache entries after successful payment processing.
- **Asynchronous Cache Updates**: Ensures data consistency between the database and cache.

These changes complete the implementation of the cache invalidation mechanism for Redis, as outlined in the project's active context.